### PR TITLE
Declare that the package doesn't provide entities

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -1,10 +1,11 @@
 <?php
 namespace Concrete\Package\MsvCloudflareTurnstile;
 
-use Concrete\Core\Package\Package;
+use Concrete\Core\Database\EntityManager\Provider\ProviderInterface;
 use Concrete\Core\Captcha\Library as CaptchaLibrary;
+use Concrete\Core\Package\Package;
 
-class Controller extends Package
+class Controller extends Package implements ProviderInterface
 {
     protected $pkgHandle = 'msv_cloudflare_turnstile';
     protected $appVersionRequired = '8.5.0';
@@ -29,5 +30,15 @@ class Controller extends Package
         $pkg = parent::install();
         CaptchaLibrary::add('turnstile', t('Cloudflare Turnstile'), $pkg);
         return $pkg;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Database\EntityManager\Provider\ProviderInterface::getDrivers()
+     */
+    public function getDrivers()
+    {
+        return [];
     }
 }


### PR DESCRIPTION
Whenever a page gets visited, Concrete boots every package.
If we declare that the package doesn't provide entities, we skip running some lines of code.
This is a really tiny bit improvement, but why not? 😉
